### PR TITLE
Change 'AND' to 'OR' in _objectDefaults condition

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -103,7 +103,7 @@ var store = {
                 if (!Array.isArray(defaults[key])) {
                     this$1._objectDefaults(defaults[key], storage[key]);
                 }
-            } else if (!storage.hasOwnProperty(key) && typeof defaults[key] !== typeof storage[key]) {
+            } else if (!storage.hasOwnProperty(key) || typeof defaults[key] !== typeof storage[key]) {
                 storage[key] = defaults[key];
             }
         }

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ const store = {
                 if (!Array.isArray(defaults[key])) {
                     this._objectDefaults(defaults[key], storage[key]);
                 }
-            } else if (!storage.hasOwnProperty(key) && typeof defaults[key] !== typeof storage[key]) {
+            } else if (!storage.hasOwnProperty(key) || typeof defaults[key] !== typeof storage[key]) {
                 storage[key] = defaults[key];
             }
         }


### PR DESCRIPTION
Looks like we made a mistake. `&&` is wrong here, because we want to replace the storage value with default value if types of such values is dismatch or create such value, if it is not exists. `||` is more correct.

I find out that because if got an error in my project. New one works perfect.

Furthermore, `!storage.hasOwnProperty(key)` !== `typeof storage[key] === undefined`? If so, it could be as simple as `typeof defaults[key] !== typeof storage[key]`, is't it?